### PR TITLE
fix: resolve file path relative to repo root in monorepo workflows

### DIFF
--- a/lua/jjui.lua
+++ b/lua/jjui.lua
@@ -138,13 +138,13 @@ end
 -- Open jjui for current file's repository
 function M.jjui_current_file()
   local orig_dir = vim.fn.getcwd()
-  vim.cmd('cd ' .. vim.fn.expand('%:p:h'))
+  vim.cmd('cd ' .. vim.fn.fnameescape(vim.fn.expand('%:p:h')))
 
   M.jjui()
 
   local orig_cb = M.config.on_exit_callback
   M.config.on_exit_callback = function()
-    vim.cmd('cd ' .. orig_dir)
+    vim.cmd('cd ' .. vim.fn.fnameescape(orig_dir))
     if orig_cb then
       orig_cb()
     end
@@ -164,12 +164,25 @@ function M.jjui_filter_current_file()
     return
   end
 
-  if not utils.get_repo_root() then
+  local repo_root = utils.get_repo_root(vim.fn.fnamemodify(file, ':h'))
+  if not repo_root then
     vim.notify('Not in a jj repository', vim.log.levels.WARN)
     return
   end
 
-  M.jjui('-r "files(' .. vim.fn.shellescape(vim.fn.fnamemodify(file, ':.')) .. ')"')
+  local rel_path = vim.fn.fnamemodify(file, ':s?' .. vim.pesc(repo_root .. '/') .. '??')
+  local orig_dir = vim.fn.getcwd()
+  vim.cmd('cd ' .. vim.fn.fnameescape(repo_root))
+
+  M.jjui('-r "files(' .. vim.fn.shellescape(rel_path) .. ')"')
+
+  local orig_cb = M.config.on_exit_callback
+  M.config.on_exit_callback = function()
+    vim.cmd('cd ' .. vim.fn.fnameescape(orig_dir))
+    if orig_cb then
+      orig_cb()
+    end
+  end
 end
 
 -- Open jjui config

--- a/lua/jjui.lua
+++ b/lua/jjui.lua
@@ -143,10 +143,11 @@ function M.jjui_current_file()
   M.jjui()
 
   local orig_cb = M.config.on_exit_callback
-  M.config.on_exit_callback = function()
+  M.config.on_exit_callback = function(...)
+    M.config.on_exit_callback = orig_cb
     vim.cmd('cd ' .. vim.fn.fnameescape(orig_dir))
     if orig_cb then
-      orig_cb()
+      orig_cb(...)
     end
   end
 end
@@ -170,17 +171,18 @@ function M.jjui_filter_current_file()
     return
   end
 
-  local rel_path = vim.fn.fnamemodify(file, ':s?' .. vim.pesc(repo_root .. '/') .. '??')
   local orig_dir = vim.fn.getcwd()
   vim.cmd('cd ' .. vim.fn.fnameescape(repo_root))
+  local rel_path = vim.fn.fnamemodify(file, ':.')
 
   M.jjui('-r "files(' .. vim.fn.shellescape(rel_path) .. ')"')
 
   local orig_cb = M.config.on_exit_callback
-  M.config.on_exit_callback = function()
+  M.config.on_exit_callback = function(...)
+    M.config.on_exit_callback = orig_cb
     vim.cmd('cd ' .. vim.fn.fnameescape(orig_dir))
     if orig_cb then
-      orig_cb()
+      orig_cb(...)
     end
   end
 end


### PR DESCRIPTION
`jjui_filter_current_file()` built the `files()` revset using a path relative to Neovim's CWD instead of the nearest `.jj/` repo root. 

In monorepos this produced incorrect revsets. Now the function finds the repo root from the file's own directory, computes the path relative to it, and `cd`s into the repo root before launching jjui — matching the pattern already used by `jjui_current_file()`. 

Also adds `fnameescape()` to `cd` commands in both functions for paths with spaces.

Fixes #2